### PR TITLE
Allow specifying file_name matcher

### DIFF
--- a/lib/nsrr/commands/download.rb
+++ b/lib/nsrr/commands/download.rb
@@ -21,6 +21,7 @@ module Nsrr
         (@token, argv) = parse_parameter_with_value(argv, ["token"], "")
         (@file_comparison, argv) = parse_parameter(argv, ["fast", "fresh", "md5"], "md5")
         (@depth, argv) = parse_parameter(argv, ["shallow", "recursive"], "recursive")
+        (@file, argv) = parse_parameter_with_value(argv, ["file"], "")
         @dataset_slug = argv[1].to_s.split("/").first
         @full_path = (argv[1].to_s.split("/")[1..-1] || []).join("/")
       end
@@ -35,7 +36,7 @@ module Nsrr
           @token = Nsrr::Helpers::Authorization.get_token(@token) if @token.to_s == ""
           @dataset = Dataset.find(@dataset_slug, @token)
           if @dataset
-            @dataset.download(@full_path, depth: @depth, method: @file_comparison)
+            @dataset.download(@full_path, depth: @depth, method: @file_comparison, file: Regexp.new(@file))
           else
             puts "\nThe dataset " + @dataset_slug.white + " was not found."
             datasets = all_datasets
@@ -80,7 +81,7 @@ module Nsrr
         result = default
         options.each do |option|
           argv.each do |arg|
-            result = arg.gsub(/^--#{option}=/, "") if arg =~ /^--#{option}=\w/
+            result = arg.gsub(/^--#{option}=/, "") if arg =~ /^--#{option}=[^\s]/
           end
         end
         [result, argv]

--- a/lib/nsrr/models/dataset.rb
+++ b/lib/nsrr/models/dataset.rb
@@ -69,6 +69,7 @@ module Nsrr
 
         begin
           puts "           File Check: " + options[:method].to_s.white
+          puts "           File Regex: " + options[:file].inspect.white
           puts "                Depth: " + options[:depth].to_s.white
           puts ""
           if @download_token.nil?
@@ -100,6 +101,12 @@ module Nsrr
         create_folder_for_path(full_path)
 
         files(full_path).select(&:is_file).each do |file|
+          unless file.file_name.match?(options[:file])
+            puts "     skipped".blue + " #{file.file_name}"
+            @files_skipped += 1
+            next
+          end
+
           current_folder = ::File.join(slug.to_s, file.folder.to_s)
           result = file.download(options[:method], current_folder, @download_token)
           case result


### PR DESCRIPTION
I'd like to specify files to be downloaded instead of just downloading all files in a folder. To do that, I added `--file` option to specify a regular expression to match a file name.

## Example
```
$ nsrr download nchsdb/health_data --file="^PROCEDURE.*\.csv$"
           File Check: md5
           File Regex: /^PROCEDURE.*\.csv$/
                Depth: recursive

      create nchsdb/health_data/
     skipped DEMOGRAPHIC.csv
     skipped DIAGNOSIS.csv
     skipped ENCOUNTER.csv
     skipped MEASUREMENT.csv
     skipped MEDICATION.csv
  downloaded PROCEDURE.csv
  downloaded PROCEDURE_SURG_HX.csv
     skipped SLEEP_ENC_ID.csv
     skipped SLEEP_STUDY.csv
     skipped Sleep_Study_Data_File_Format.pdf

Finished in 3.458583493 seconds.

1 folder created, 2 files downloaded, 27 MiBs downloaded, 8 files skipped, 0 files failed
```