### PR TITLE
Read Token from Environment

### DIFF
--- a/lib/nsrr/helpers/authorization.rb
+++ b/lib/nsrr/helpers/authorization.rb
@@ -2,17 +2,25 @@
 
 require "nsrr/helpers/color"
 require "nsrr/helpers/json_request"
+require 'io/console'
 
 module Nsrr
   module Helpers
     # Helper to verify that user is authenticated.
     class Authorization
       def self.get_token(token)
-        puts  "  Get your token here: " + "#{Nsrr::WEBSITE}/token".bg_gray.blue.underline
-        puts  "  Your input is hidden while entering token.".white
-        print "     Enter your token: "
-        token = STDIN.noecho(&:gets).chomp if token.to_s.strip == ""
-        token.strip!
+        # Try to read the token from the environment.
+        token = ENV['NSRR_TOKEN']
+        # Check if the token is nil or empty
+        if token.to_s.strip.empty?
+            puts  "  Get your token here: " + "#{Nsrr::WEBSITE}/token".bg_gray.blue.underline
+            puts  "  Your input is hidden while entering token.".white
+            print "     Enter your token: "
+            token = STDIN.noecho(&:gets).chomp if token.to_s.strip == ""
+            token.strip!
+        else
+            puts  "  Using token from environment variable NSRR_TOKEN."
+        end
         (response, _status) = Nsrr::Helpers::JsonRequest.get("#{Nsrr::WEBSITE}/api/v1/account/profile.json", auth_token: token)
         if response.is_a?(Hash) && response["authenticated"]
           puts "AUTHORIZED".green + " as " + "#{response["first_name"]} #{response["last_name"]}".white


### PR DESCRIPTION
Enables the ability to read the token from an environment variable called NSRR_TOKEN. This means that the download gem can be used in a non-interactive fashion.